### PR TITLE
Preserve relative import sources

### DIFF
--- a/lib/pipelines/buildAmd.js
+++ b/lib/pipelines/buildAmd.js
@@ -40,7 +40,7 @@ function buildAmdNoSourceMaps(options) {
 		babel: {
 			compact: false,
 			resolveModuleSource: function(source, filename) {
-				return getAmdModuleId(renameWithoutJsExt(source, filename), options);
+				return source[0] === '.' ? source : getAmdModuleId(renameWithoutJsExt(source, filename), options);
 			},
 			plugins: [babelPluginAmd],
 			presets: options.babelPresets,

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "vinyl-fs": "^2.2.1"
   },
   "devDependencies": {
+    "bower-directory": "^1.0.0",
     "del": "^2.1.0",
     "jshint": "^2.7.0",
     "mocha": "^2.2.5",

--- a/test/fixtures/js/relativeImport.js
+++ b/test/fixtures/js/relativeImport.js
@@ -1,0 +1,3 @@
+'use strict';
+
+import relativeModule from './foo';

--- a/test/lib/pipelines/buildAmd.js
+++ b/test/lib/pipelines/buildAmd.js
@@ -95,4 +95,17 @@ describe('Pipeline - Build AMD', function() {
       }
 		});
 	});
+
+  it('should preserve relative paths as module ids', function(done) {
+    var stream = vfs.src('test/fixtures/js/relativeImport.js')
+      .pipe(buildAmd());
+
+    stream.on('data', function(file) {
+      if (file.relative === 'metal/test/fixtures/js/relativeImport.js') {
+        var contents = file.contents.toString();
+        assert.notStrictEqual(-1, contents.indexOf('define([\'./foo\']'));
+        done();
+      }
+    });
+  });
 });


### PR DESCRIPTION
Hey @mairatma, @eduardolundgren, this is a possible fix for #1.

What do you think? Was there a reason why we would always transform relative paths? 
